### PR TITLE
Add header for boost::scoped_ptr

### DIFF
--- a/include/warehouse_ros/database_loader.h
+++ b/include/warehouse_ros/database_loader.h
@@ -40,6 +40,8 @@
 #include <warehouse_ros/database_connection.h>
 #include <pluginlib/class_loader.h>
 
+#include <boost/scoped_ptr.hpp>
+
 namespace warehouse_ros
 {
 


### PR DESCRIPTION
required for compilation on Ubuntu Xenial
